### PR TITLE
Allow user to change name of migrations with config

### DIFF
--- a/bin/doctrine-laravel.php
+++ b/bin/doctrine-laravel.php
@@ -44,7 +44,7 @@ $helperSet = new HelperSet(array(
 ));
 
 $migrations_config = new Configuration($em->getConnection());
-$migrations_config->setName('Doctrine Sandbox Migrations');
+$migrations_config->setName(Config::get('laravel-doctrine::doctrine.migrations.name', 'Doctrine Sandbox Migrations'));
 $migrations_config->setMigrationsNamespace('DoctrineMigrations');
 $migrations_config->setMigrationsTableName(Config::get('laravel-doctrine::doctrine.migrations.table_name', 'doctrine_migration_versions'));
 


### PR DESCRIPTION
Tiny update, but some user's might find it useful if they are anal about such things. Allows the change of the name the migrations report.

```
'migrations' => array(
    'name'       => 'My Custom Name',
    'directory'  => '/database/migrations',
    'table_name' => 'migration_versions'
)
```

The name defaults to _Doctrine Sandbox Migrations_ if no config item is present.
