### PR TITLE
Updated composer.json to work with laravel 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.0.x",
+        "illuminate/support": "4.*.x",
 	    "doctrine/orm": "2.*",
         "doctrine/migrations": "dev-master"
     },


### PR DESCRIPTION
First time making a pull request, so I apologize if I've done anything incorrectly.    

```
$user: /var/www/laravel$ composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: remove laravel/framework v4.1.3
    - Conclusion: don't install laravel/framework v4.1.3
    - Installation request for atrauzzi/laravel-doctrine dev-master -> satisfiable by atrauzzi/laravel-doctrine[dev-master].
    - Conclusion: don't install laravel/framework v4.1.2
    - Conclusion: don't install laravel/framework v4.1.1
    - atrauzzi/laravel-doctrine dev-master requires illuminate/support 4.0.x -> satisfiable by laravel/framework[v4.0.0, v4.0.1, v4.0.10, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9], illuminate/support[v4.0.0, v4.0.1, v4.0.10, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9].
    - Can only install one of: laravel/framework[v4.1.0, v4.0.0].
    - Can only install one of: laravel/framework[v4.1.0, v4.0.1].
    - Can only install one of: laravel/framework[v4.1.0, v4.0.10].
    - Can only install one of: laravel/framework[v4.1.0, v4.0.2].
    - Can only install one of: laravel/framework[v4.1.0, v4.0.3].
    - Can only install one of: laravel/framework[v4.1.0, v4.0.4].
    - Can only install one of: laravel/framework[v4.1.0, v4.0.5].
    - Can only install one of: laravel/framework[v4.1.0, v4.0.6].
    - Can only install one of: laravel/framework[v4.1.0, v4.0.7].
    - Can only install one of: laravel/framework[v4.1.0, v4.0.8].
    - Can only install one of: laravel/framework[v4.1.0, v4.0.9].
    - don't install illuminate/support v4.0.0|don't install laravel/framework v4.1.0
    - don't install illuminate/support v4.0.1|don't install laravel/framework v4.1.0
    - don't install illuminate/support v4.0.10|don't install laravel/framework v4.1.0
    - don't install illuminate/support v4.0.2|don't install laravel/framework v4.1.0
    - don't install illuminate/support v4.0.3|don't install laravel/framework v4.1.0
    - don't install illuminate/support v4.0.4|don't install laravel/framework v4.1.0
    - don't install illuminate/support v4.0.5|don't install laravel/framework v4.1.0
    - don't install illuminate/support v4.0.6|don't install laravel/framework v4.1.0
    - don't install illuminate/support v4.0.7|don't install laravel/framework v4.1.0
    - don't install illuminate/support v4.0.8|don't install laravel/framework v4.1.0
    - don't install illuminate/support v4.0.9|don't install laravel/framework v4.1.0
    - Installation request for laravel/framework 4.1.* -> satisfiable by laravel/framework[v4.1.0, v4.1.1, v4.1.2, v4.1.3].


$user: /var/www/laravel$ php -v
PHP 5.4.9-4ubuntu2.3 (cli) (built: Sep  4 2013 19:32:25) 
Copyright (c) 1997-2012 The PHP Group
Zend Engine v2.4.0, Copyright (c) 1998-2012 Zend Technologies
    with Xdebug v2.2.1, Copyright (c) 2002-2012, by Derick Rethans
```

And The composer.json file

```
{
    "name": "laravel/laravel",
    "description": "The Laravel Framework.",
    "keywords": ["framework", "laravel"],
    "license": "MIT",
    "require": {
             "laravel/framework": "4.1.*",
             "atrauzzi/laravel-doctrine": "dev-master",
             "doctrine/migrations": "dev-master",
    },
    "autoload": {
        "classmap": [
            "app/commands",
            "app/controllers",
            "app/models",
            "app/database/migrations",
            "app/database/seeds",
            "app/tests/TestCase.php"
        ],
        "psr-0": {
            "SomeApp\\": "app/src/"
        }
    },
    "scripts": {
        "post-install-cmd": [
            "php artisan optimize"
        ],
        "post-update-cmd": [
            "php artisan clear-compiled",
            "php artisan optimize"
        ],
        "post-create-project-cmd": [
            "php artisan key:generate"
        ]
    },
    "config": {
        "preferred-install": "dist"
    },
    "minimum-stability": "stable"
}
```

I'm not certain, but it could be possible the fix is as simple as updating the Illuminate\Support [dependency](https://github.com/atrauzzi/laravel-doctrine/blob/master/composer.json#L14).

I manuallly copied your package into my vendor directory and update the composer.json file to use `"illuminate/support": "4.*.x",` and it appears everything was working fine like it did pre- 4.1
