### PR TITLE
Registering provider package namespace in register()

### DIFF
--- a/src/Atrauzzi/LaravelDoctrine/ServiceProvider.php
+++ b/src/Atrauzzi/LaravelDoctrine/ServiceProvider.php
@@ -31,6 +31,7 @@ class ServiceProvider extends Base {
 	 * @return void
 	 */
 	public function register() {
+		$this->package('atrauzzi/laravel-doctrine');
 
 		//
 		// Doctrine


### PR DESCRIPTION
Lets the config repository know about the 'laravel-doctrine' package config namespace earlier.
We have code that tries to get <code>$config->get('laravel-doctrine::doctrine.metadata')</code> before the service provider's boot() method is called. This is currently a problem because the config repository doesn't know about the laravel-doctrine package until a call to <code>$this->package('laravel-doctrine')</code> is called in the boot() method.
