### PR TITLE
Update doctrine/migrations requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.3.0",
         "illuminate/support": "4.0.x",
 	    "doctrine/orm": "2.*",
-        "doctrine/migrations": "dev-master"
+        "doctrine/migrations": "1.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
doctrine/migrations has moved to 1.\* and dev-master isn't available anymore.
