### PR TITLE
Added Memcached cache driver support

### DIFF
--- a/src/Atrauzzi/LaravelDoctrine/ServiceProvider.php
+++ b/src/Atrauzzi/LaravelDoctrine/ServiceProvider.php
@@ -76,6 +76,15 @@ class ServiceProvider extends Base {
 						}
 						break;
 
+					case 'memcached':
+						if(extension_loaded('memcached')) {
+							$memcache = new \Memcached();
+							$memcache->addServer($cache_provider_config['host'], $cache_provider_config['port']);
+							$cache = new \Doctrine\Common\Cache\MemcachedCache();
+							$cache->setMemcached($memcache);
+						}
+						break;
+
 					case 'couchbase':
 						if(extension_loaded('couchbase')) {
 							$couchbase = new \Couchbase(


### PR DESCRIPTION
Currently it was not possible to configure memcached driver, so we just added a few configuration lines to make this possible.

http://doctrine-orm.readthedocs.org/en/latest/reference/caching.html#memcached