### PR TITLE
Bugfixes on ServiceProvider and bin/doctrine-laravel.php working

### DIFF
--- a/bin/doctrine-laravel.php
+++ b/bin/doctrine-laravel.php
@@ -32,10 +32,12 @@ use Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand;
 
 require __DIR__.'/../../../../bootstrap/autoload.php';
-$app = require_once __DIR__.'/../../../../bootstrap/start.php';
-$app->boot();
+$app = require_once __DIR__.'/../../../../bootstrap/app.php';
 
-$em = App::make('doctrine');
+$app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+$config = $app->make('config');
+
+$em = $app->make('Doctrine\ORM\EntityManager');
 
 $helperSet = new HelperSet(array(
 	'db' => new ConnectionHelper($em->getConnection()),
@@ -44,11 +46,11 @@ $helperSet = new HelperSet(array(
 ));
 
 $migrations_config = new Configuration($em->getConnection());
-$migrations_config->setName(Config::get('laravel-doctrine::doctrine.migrations.name', 'Doctrine Sandbox Migrations'));
-$migrations_config->setMigrationsNamespace(Config::get('laravel-doctrine::doctrine.migrations.namespace', 'DoctrineMigrations'));
-$migrations_config->setMigrationsTableName(Config::get('laravel-doctrine::doctrine.migrations.table_name', 'doctrine_migration_versions'));
+$migrations_config->setName($config->get('doctrine.migrations.name', 'Doctrine Sandbox Migrations'));
+$migrations_config->setMigrationsNamespace($config->get('doctrine.migrations.namespace', 'DoctrineMigrations'));
+$migrations_config->setMigrationsTableName($config->get('doctrine.migrations.table_name', 'doctrine_migration_versions'));
 
-$migrations_directory = App::make('path').Config::get('laravel-doctrine::doctrine.migrations.directory', '/database/doctrine-migrations');
+$migrations_directory = base_path($config->get('doctrine.migrations.directory', 'database/doctrine-migrations'));
 $migrations_config->setMigrationsDirectory($migrations_directory);
 $migrations_config->registerMigrationsFromDirectory($migrations_directory);
 

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -15,7 +15,8 @@
 			'driver' => 'config'
 		],
 		[
-			'driver' => 'annotation'
+			'driver' => 'annotation',
+			'namespace' => 'App'
 		]
 		//
 		// ...accepting PRs for more!
@@ -65,18 +66,15 @@
 	 *
 	 * http://doctrine-dbal.readthedocs.org/en/latest/reference/configuration.html#connection-details
 	 */
-	/*
 	'connection' => [
 
-		'driver' => '',
-		'user' => '',
-		'password' => '',
-		'dbname' => '',
-		'host' => '',
+		'driver' => 'mysqli',
+		'host'      => env('DB_HOST', 'localhost'),
+		'dbname'  => env('DB_DATABASE', 'forge'),
+		'user'  => env('DB_USERNAME', 'forge'),
+		'password'  => env('DB_PASSWORD', ''),
 		'prefix' => ''
-
 	],
-	*/
 
 	/*
 	 * By default, this package mimics the cache configuration from Laravel.

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -23,6 +23,22 @@
 		public function boot() {
 
 			Type::addType('json', '\Atrauzzi\LaravelDoctrine\Type\Json');
+			$this->publishes([
+				__DIR__ . '/../config/doctrine.php' => config_path('doctrine.php')
+			]);
+			$this->commands([
+				'Atrauzzi\LaravelDoctrine\Console\CreateSchemaCommand',
+				'Atrauzzi\LaravelDoctrine\Console\UpdateSchemaCommand',
+				'Atrauzzi\LaravelDoctrine\Console\DropSchemaCommand'
+			]);
+		}
+
+		/**
+		 * Register the service provider.
+		 *
+		 * @return void
+		 */
+		public function register() {
 
 			$this->app->singleton('Doctrine\ORM\EntityManager', function (Application $app) {
 
@@ -41,7 +57,7 @@
 					'driver' => 'config'
 				]);
 
-				if(!empty($metadataConfig) && is_array($metadataConfig[0])) {
+				if(!empty($metadataConfig) && isset($metadataConfig[0]) && is_array($metadataConfig[0])) {
 
 					$metadataDriver = new \Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain();
 
@@ -108,26 +124,6 @@
 			$this->app->singleton('doctrine.connection', function (Application $app) {
 				return $app->make('Doctrine\ORM\EntityManager')->getConnection();
 			});
-
-		}
-
-		/**
-		 * Register the service provider.
-		 *
-		 * @return void
-		 */
-		public function register() {
-
-			$this->publishes([
-				__DIR__ . '/../config/doctrine.php' => config_path('doctrine.php')
-			]);
-
-			$this->commands([
-				'Atrauzzi\LaravelDoctrine\Console\CreateSchemaCommand',
-				'Atrauzzi\LaravelDoctrine\Console\UpdateSchemaCommand',
-				'Atrauzzi\LaravelDoctrine\Console\DropSchemaCommand'
-			]);
-
 		}
 
 		/**


### PR DESCRIPTION
Hi Alexander,

There was a bug on the metadataConfig array check that made the package unusable for single metadata readers, as an unexisting array position was being checked against is_array.
I also moved the EntityManager singleton declaration to "register" method, as I was having problems to use it for Gedmo Doctrine Extensions initialization.

doctrine-laravel.php was unusable too, so I upgraded bootstraping to Laravel 5 methodology.

I also added .env db configuration to the database driver, so laravel config may be reused if set from .env file.

I hope nothing is broken with this changes and they can be merged.