### PR TITLE
Allow "devMode" to be configured independently from app.debug

### DIFF
--- a/src/Atrauzzi/LaravelDoctrine/ServiceProvider.php
+++ b/src/Atrauzzi/LaravelDoctrine/ServiceProvider.php
@@ -43,7 +43,7 @@ class ServiceProvider extends Base {
 			// Retrieve our configuration.
 			$config = $app['config'];
 			$connection = $config->get('laravel-doctrine::doctrine.connection');
-			$devMode = $config->get('app.debug');
+			$devMode = $config->get('laravel-doctrine::devMode');
 
 			$cache = null; // Default, let Doctrine decide.
 

--- a/src/Atrauzzi/LaravelDoctrine/ServiceProvider.php
+++ b/src/Atrauzzi/LaravelDoctrine/ServiceProvider.php
@@ -41,9 +41,10 @@ class ServiceProvider extends Base {
 		$this->app->singleton('Doctrine\ORM\EntityManager', function ($app) {
 
 			// Retrieve our configuration.
+			/** @var \Illuminate\Config\Repository $config */
 			$config = $app['config'];
 			$connection = $config->get('laravel-doctrine::doctrine.connection');
-			$devMode = $config->get('laravel-doctrine::doctrine.devMode');
+			$devMode = $config->get('laravel-doctrine::doctrine.devMode', $config->get('app.debug'));
 
 			$cache = null; // Default, let Doctrine decide.
 

--- a/src/Atrauzzi/LaravelDoctrine/ServiceProvider.php
+++ b/src/Atrauzzi/LaravelDoctrine/ServiceProvider.php
@@ -43,7 +43,7 @@ class ServiceProvider extends Base {
 			// Retrieve our configuration.
 			$config = $app['config'];
 			$connection = $config->get('laravel-doctrine::doctrine.connection');
-			$devMode = $config->get('laravel-doctrine::devMode');
+			$devMode = $config->get('laravel-doctrine::doctrine.devMode');
 
 			$cache = null; // Default, let Doctrine decide.
 

--- a/src/config/doctrine.php
+++ b/src/config/doctrine.php
@@ -4,6 +4,18 @@ return array(
 
 	/*
 	|--------------------------------------------------------------------------
+	| Development Mode
+	|--------------------------------------------------------------------------
+	|
+	| If set to true, caching is done in memory with the ArrayCache. Proxy objects are recreated on every request.
+	|
+	| http://doctrine-orm.readthedocs.org/en/latest/reference/configuration.html#obtaining-an-entitymanager
+	|
+	*/
+	'devMode' => false,
+
+	/*
+	|--------------------------------------------------------------------------
 	| Database Connection
 	|--------------------------------------------------------------------------
 	|

--- a/src/config/doctrine.php
+++ b/src/config/doctrine.php
@@ -6,13 +6,14 @@ return array(
 	|--------------------------------------------------------------------------
 	| Development Mode
 	|--------------------------------------------------------------------------
-	|
-	| If set to true, caching is done in memory with the ArrayCache. Proxy objects are recreated on every request.
+	| When true, caching is done in memory with the ArrayCache. Proxy objects are recreated on every request.
 	|
 	| http://doctrine-orm.readthedocs.org/en/latest/reference/configuration.html#obtaining-an-entitymanager
 	|
+	| If not set, the value from Laravel's app.debug will be used.
+	|
 	*/
-	'devMode' => false,
+	//'devMode' => false,
 
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
This was discussed in https://github.com/atrauzzi/laravel-doctrine/issues/33, but it doesn't look like anyone else submitted a PR.  This will help eliminate Doctrine bottlenecks when profiling an app in development, while Laravel's app.debug configuration parameter is enabled.