### PR TITLE
XML and YAML Configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
 		"php": ">=5.4.0",
 		"laravel/framework": "5.0.*@dev",
 		"doctrine/orm": "2.4.*",
-		"doctrine/migrations": "dev-master#46a031ddaea47d0685200027cfe8c83b02aee6f6"
+		"doctrine/migrations": "dev-master#46a031ddaea47d0685200027cfe8c83b02aee6f6",
+        "beberlei/DoctrineExtensions": "1.0.*@dev"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"laravel/framework": "5.0.*@dev",
 		"doctrine/orm": "2.4.*",
 		"doctrine/migrations": "dev-master#46a031ddaea47d0685200027cfe8c83b02aee6f6",
-        "beberlei/DoctrineExtensions": "1.0.*@dev"
+		"beberlei/DoctrineExtensions": "1.0.*@dev"
 	},
 	"autoload": {
 		"psr-4": {

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -18,12 +18,12 @@
 			'driver' => 'annotation',
 		//	'namespace' => 'App'
 		],
-        [
-            'driver'=>'yaml',
-        ],
-        [
-            'driver'=>'xml'
-        ]
+		[
+			'driver'=>'yaml',
+		],
+		[
+			'driver'=>'xml'
+		]
 		//
 		// ...accepting PRs for more!
 
@@ -129,10 +129,10 @@
 		'table_name' => 'doctrine_migration_versions'
 	],
 
- 	/*
+	/*
 	|--------------------------------------------------------------------------
 	| Use to specify the default repository
-    | http://doctrine-orm.readthedocs.org/en/latest/reference/working-with-objects.html#custom-repositories
+	| http://doctrine-orm.readthedocs.org/en/latest/reference/working-with-objects.html#custom-repositories
 	|--------------------------------------------------------------------------
 	*/
 	/*
@@ -154,7 +154,7 @@
 
 	/*
 	 * In some circumstances, you may wish to diverge from what's configured in Laravel.
- 	 */
+	 */
 	//'debug' => false,
 
 ];

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -17,7 +17,13 @@
 		[
 			'driver' => 'annotation',
 		//	'namespace' => 'App'
-		]
+		],
+        [
+            'driver'=>'yaml',
+        ],
+        [
+            'driver'=>'xml'
+        ]
 		//
 		// ...accepting PRs for more!
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -11,6 +11,8 @@
 	use Doctrine\ORM\EntityManager;
 	use Doctrine\ORM\Tools\SchemaTool;
 	use RuntimeException;
+    use Doctrine\ORM\Mapping\Driver\YamlDriver;
+    use Doctrine\ORM\Mapping\Driver\XmlDriver;
 
 
 	class ServiceProvider extends Base {
@@ -164,6 +166,16 @@
 						array_get($driverConfig, 'simple', false)
 					);
 				break;
+
+                case 'yaml':
+                    $driver = new YamlDriver(array_get($driverConfig, 'paths', app_path()));
+                    $config->setMetadataDriverImpl($driver);
+                break;
+
+                case 'xml':
+                    $driver = new XmlDriver(array_get($driverConfig, 'paths', app_path()));
+                    $config->setMetadataDriverImpl($driver);
+                break;
 
 				case null:
 					throw new RuntimeException('Metadata driver has unspecified type.');

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -80,6 +80,20 @@
 
 				$doctrineConfig->setMetadataDriverImpl($metadataDriver);
 
+                //add in trig functions to doctrine for mysql
+                $doctrineConfig->setCustomNumericFunctions(array(
+                    'ACOS'    => 'DoctrineExtensions\Query\Mysql\Acos',
+                    'ASIN'    => 'DoctrineExtensions\Query\Mysql\Asin',
+                    'ATAN'    => 'DoctrineExtensions\Query\Mysql\Atan',
+                    'ATAN2'   => 'DoctrineExtensions\Query\Mysql\Atan2',
+                    'COS'     => 'DoctrineExtensions\Query\Mysql\Cos',
+                    'COT'     => 'DoctrineExtensions\Query\Mysql\Cot',
+                    'DEGREES' => 'DoctrineExtensions\Query\Mysql\Degrees',
+                    'RADIANS' => 'DoctrineExtensions\Query\Mysql\Radians',
+                    'SIN'     => 'DoctrineExtensions\Query\Mysql\Sin',
+                    'TAN'     => 'DoctrineExtensions\Query\Mysql\Tan'
+                ));
+
 				// Note: These must occur after Setup::createAnnotationMetadataConfiguration() in order to set custom namespaces properly
 				if($cache) {
 					$doctrineConfig->setMetadataCacheImpl($cache);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -182,13 +182,11 @@
 				break;
 
                 case 'yaml':
-                    $driver = new YamlDriver(array_get($driverConfig, 'paths', app_path()));
-                    $config->setMetadataDriverImpl($driver);
+                    return new YamlDriver(array_get($driverConfig, 'paths', app_path()));
                 break;
 
                 case 'xml':
-                    $driver = new XmlDriver(array_get($driverConfig, 'paths', app_path()));
-                    $config->setMetadataDriverImpl($driver);
+                    return new XmlDriver(array_get($driverConfig, 'paths', app_path()));
                 break;
 
 				case null:

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -11,8 +11,8 @@
 	use Doctrine\ORM\EntityManager;
 	use Doctrine\ORM\Tools\SchemaTool;
 	use RuntimeException;
-    use Doctrine\ORM\Mapping\Driver\YamlDriver;
-    use Doctrine\ORM\Mapping\Driver\XmlDriver;
+	use Doctrine\ORM\Mapping\Driver\YamlDriver;
+	use Doctrine\ORM\Mapping\Driver\XmlDriver;
 
 
 	class ServiceProvider extends Base {
@@ -25,7 +25,7 @@
 		public function boot() {
 
 			Type::addType('json', '\Atrauzzi\LaravelDoctrine\Type\Json');
-                        $this->publishes([__DIR__ .'/..'. '/config/doctrine.php'=> config_path('doctrine.php')], 'config');
+						$this->publishes([__DIR__ .'/..'. '/config/doctrine.php'=> config_path('doctrine.php')], 'config');
 			$this->commands([
 				'Atrauzzi\LaravelDoctrine\Console\CreateSchemaCommand',
 				'Atrauzzi\LaravelDoctrine\Console\UpdateSchemaCommand',
@@ -80,19 +80,19 @@
 
 				$doctrineConfig->setMetadataDriverImpl($metadataDriver);
 
-                //add in trig functions to doctrine for mysql
-                $doctrineConfig->setCustomNumericFunctions(array(
-                    'ACOS'    => 'DoctrineExtensions\Query\Mysql\Acos',
-                    'ASIN'    => 'DoctrineExtensions\Query\Mysql\Asin',
-                    'ATAN'    => 'DoctrineExtensions\Query\Mysql\Atan',
-                    'ATAN2'   => 'DoctrineExtensions\Query\Mysql\Atan2',
-                    'COS'     => 'DoctrineExtensions\Query\Mysql\Cos',
-                    'COT'     => 'DoctrineExtensions\Query\Mysql\Cot',
-                    'DEGREES' => 'DoctrineExtensions\Query\Mysql\Degrees',
-                    'RADIANS' => 'DoctrineExtensions\Query\Mysql\Radians',
-                    'SIN'     => 'DoctrineExtensions\Query\Mysql\Sin',
-                    'TAN'     => 'DoctrineExtensions\Query\Mysql\Tan'
-                ));
+				//add in trig functions to doctrine for mysql
+				$doctrineConfig->setCustomNumericFunctions(array(
+					'ACOS'    => 'DoctrineExtensions\Query\Mysql\Acos',
+					'ASIN'    => 'DoctrineExtensions\Query\Mysql\Asin',
+					'ATAN'    => 'DoctrineExtensions\Query\Mysql\Atan',
+					'ATAN2'   => 'DoctrineExtensions\Query\Mysql\Atan2',
+					'COS'     => 'DoctrineExtensions\Query\Mysql\Cos',
+					'COT'     => 'DoctrineExtensions\Query\Mysql\Cot',
+					'DEGREES' => 'DoctrineExtensions\Query\Mysql\Degrees',
+					'RADIANS' => 'DoctrineExtensions\Query\Mysql\Radians',
+					'SIN'     => 'DoctrineExtensions\Query\Mysql\Sin',
+					'TAN'     => 'DoctrineExtensions\Query\Mysql\Tan'
+				));
 
 				// Note: These must occur after Setup::createAnnotationMetadataConfiguration() in order to set custom namespaces properly
 				if($cache) {
@@ -181,13 +181,13 @@
 					);
 				break;
 
-                case 'yaml':
-                    return new YamlDriver(array_get($driverConfig, 'paths', app_path()));
-                break;
+				case 'yaml':
+					return new YamlDriver(array_get($driverConfig, 'paths', app_path()));
+				break;
 
-                case 'xml':
-                    return new XmlDriver(array_get($driverConfig, 'paths', app_path()));
-                break;
+				case 'xml':
+					return new XmlDriver(array_get($driverConfig, 'paths', app_path()));
+				break;
 
 				case null:
 					throw new RuntimeException('Metadata driver has unspecified type.');


### PR DESCRIPTION
# YAML and XML Configuration 

I've gone ahead and added in YAML and XML to the ServiceProvider by implementing YAMLDriver and XMLDriver into the switch statement for determining the driver. To use, just update the 'driver' key to YAML or XML respectively. In addition, define your 'paths' key to where ever your mapping files are located. 

# DoctrineExtensions

I've also added in DoctrineExtensions which allow you to use trig functions in SQL such as COS, ACOS (etc). If this is not desirable, I can remove this extension from the code. 

Any feedback or things that I've executed properly, please let me know and I will take care of them.