### PR TITLE
Rename Trait directory to Util

### DIFF
--- a/src/Util/Time.php
+++ b/src/Util/Time.php
@@ -1,6 +1,6 @@
 <?php 
 
-namespace Atrauzzi\LaravelDoctrine\Trait;
+namespace Atrauzzi\LaravelDoctrine\Util;
 use Doctrine\ORM\Mapping AS ORM;
 use DateTime;
 


### PR DESCRIPTION
Since Trait is a reserved word I renamed this directory to Util to avoid errors when importing the Time trait into an entity. I'm not sure if this actually leads to a runtime error or not yet, but my IDE sure didn't like it.