### PR TITLE
Extract custom types like the included Json type into configuration.

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -158,4 +158,14 @@
 	 */
 	//'debug' => false,
 
+    /*
+    | ---------------------------------
+    | Add custom Doctrine types here
+    | For more information: http://doctrine-dbal.readthedocs.org/en/latest/reference/types.html#custom-mapping-types
+    | ---------------------------------
+    */
+    'custom_types' => [
+        'json' => 'Atrauzzi\LaravelDoctrine\Type\Json'
+    ]
+
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -24,9 +24,11 @@
 		 */
 		public function boot() {
 
-			Type::addType('json', '\Atrauzzi\LaravelDoctrine\Type\Json');
-						$this->publishes([__DIR__ .'/..'. '/config/doctrine.php'=> config_path('doctrine.php')], 'config');
-			$this->commands([
+            $this->registerCustomTypes();
+
+            $this->publishes([__DIR__ .'/..'. '/config/doctrine.php'=> config_path('doctrine.php')], 'config');
+
+            $this->commands([
 				'Atrauzzi\LaravelDoctrine\Console\CreateSchemaCommand',
 				'Atrauzzi\LaravelDoctrine\Console\UpdateSchemaCommand',
 				'Atrauzzi\LaravelDoctrine\Console\DropSchemaCommand'
@@ -299,6 +301,14 @@
 
 		}
 
-	}
+        protected function registerCustomTypes()
+        {
+            foreach(config('doctrine.custom_types',array()) as $name=>$class)
+            {
+                Type::addType($name, $class);
+            }
+        }
+
+    }
 
 }


### PR DESCRIPTION
Added a custom_types configuration array and refactored the Type::addType for json into a simple loop through the values in the configuration file at boot.