### PR TITLE
Cachefactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 .*~
 .idea
 atlassian-ide-plugin.xml
+.vagrant

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	"require": {
 		"php": ">=5.4.0",
 		"laravel/framework": "5.0.*@dev",
-		"doctrine/orm": "2.4.*",
+		"doctrine/orm": "2.5.*",
 		"doctrine/migrations": "dev-master#46a031ddaea47d0685200027cfe8c83b02aee6f6",
 		"beberlei/DoctrineExtensions": "1.0.*@dev"
 	},

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -84,14 +84,18 @@
 	],
 
 	/*
-	 * By default, this package mimics the cache configuration from Laravel.
-	 *
-	 * Cache providers, supports apc, xcache, memcache, redis.
+    | ---------------------------------
+	| By default, this package mimics the cache configuration from Laravel.
+	|
+	| You can create your own cache provider by extending the
+	| Atrauzzi\LaravelDoctrine\CacheProvider\CacheProvider class.
+	|
+	| Each provider requires a like named section with an array of configuration options.
+	| ----------------------------------
 	 */
-	/*
 	'cache' => [
-
-		'provider' => 'redis',
+        // Remove or set to null for no cache
+		'provider' => 'array',
 
 		'redis' => [
 			'host'     => '127.0.0.1',
@@ -102,9 +106,20 @@
 		'memcache' => [
 			'host' => '127.0.0.1',
 			'port' => 11211
-		]
+		],
+
+        'providers' => [
+            'memcache' => 'Atrauzzi\LaravelDoctrine\CacheProvider\MemcacheProvider',
+            'memcached' => 'Atrauzzi\LaravelDoctrine\CacheProvider\MemcachedProvider',
+            'couchbase' => 'Atrauzzi\LaravelDoctrine\CacheProvider\CouchebaseProvider',
+            'redis' => 'Atrauzzi\LaravelDoctrine\CacheProvider\RedisProvider',
+            'apc' => 'Atrauzzi\LaravelDoctrine\CacheProvider\ApcProvider',
+            'xcache' => 'Atrauzzi\LaravelDoctrine\CacheProvider\XcacheProvider',
+            'array' => 'Atrauzzi\LaravelDoctrine\CacheProvider\ArrayProvider'
+            //'custom' => 'Path\To\Your\Class'
+        ]
 	],
-	*/
+
 
 	/*
 	|--------------------------------------------------------------------------
@@ -164,7 +179,7 @@
     | For more information: http://doctrine-dbal.readthedocs.org/en/latest/reference/types.html#custom-mapping-types
     | ---------------------------------
     */
-    'custom_types' =>
+    'custom_types' => [
         'json' => 'Atrauzzi\LaravelDoctrine\Type\Json'
     ]
 

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -1,0 +1,94 @@
+<?php namespace Atrauzzi\LaravelDoctrine;
+
+class CacheFactory {
+
+    public static function getInstance($type, $namespace)
+    {
+
+        switch($type) {
+
+            case 'memcache':
+
+                $memcache = new \Memcache();
+                $memcache->connect(
+                    config('doctrine.cache.memcache.host'),
+                    config('doctrine.cache.memcache.port')
+                );
+
+                $cache = new \Doctrine\Common\Cache\MemcacheCache();
+
+                $cache->setMemcache($memcache);
+
+                break;
+
+            case 'memcached':
+
+                $memcache = new \Memcached();
+                $memcache->addServer(
+                    config('doctrine.cache.memcached.host', config('cache.stores.memcached.0.host')),
+                    config('doctrine.cache.memcached.port', config('cache.stores.memcached.0.port'))
+                );
+
+                $cache = new \Doctrine\Common\Cache\MemcachedCache();
+
+                $cache->setMemcached($memcache);
+
+                break;
+
+            case 'couchbase':
+
+                $couchbase = new \Couchbase(
+                    config('doctrine.cache.couchbase.hosts'),
+                    config('doctrine.cache.couchbase.user'),
+                    config('doctrine.cache.couchbase.password'),
+                    config('doctrine.cache.couchbase.bucket'),
+                    config('doctrine.cache.couchbase.persistent')
+                );
+
+                $cache = new \Doctrine\Common\Cache\CouchbaseCache();
+
+                $cache->setCouchbase($couchbase);
+
+                break;
+
+            case 'redis':
+
+                $redis = new \Redis();
+                $redis->connect(
+                    config('doctrine.cache.redis.host', config('database.redis.default.host')),
+                    config('doctrine.cache.redis.port', config('database.redis.default.port'))
+                );
+
+                if($database = config('doctrine.cache.redis.database', config('database.redis.default.database')))
+                    $redis->select($database);
+
+                $cache = new \Doctrine\Common\Cache\RedisCache();
+
+                $cache->setRedis($redis);
+
+                break;
+
+            case 'apc':
+                $cache = new \Doctrine\Common\Cache\ApcCache();
+                break;
+
+            case 'xcache':
+                $cache = new \Doctrine\Common\Cache\XcacheCache();
+                break;
+
+            default:
+                $cache = new \Doctrine\Common\Cache\ArrayCache();
+                break;
+
+        }
+
+        if(
+            $cache instanceof \Doctrine\Common\Cache\CacheProvider
+            && $namespace = config('doctrine.cache.namespace', config('cache.prefix'))
+        )
+            $cache->setNamespace($namespace);
+
+        return $cache;
+    }
+
+}

--- a/src/CacheProvider/ApcCacheProvider.php
+++ b/src/CacheProvider/ApcCacheProvider.php
@@ -1,0 +1,20 @@
+<?php  namespace Atrauzzi\LaravelDoctrine\CacheProvider;
+
+use Doctrine\Common\Cache\ApcCache;
+
+/**
+ * Class MemcachedProvider
+ * @package Atrauzzi\LaravelDoctrine\CacheProvider
+ */
+class ApcCacheProvider extends CacheProvider{
+
+    /**
+     * Sets up and returns the CacheProvider
+     * @param $config
+     * @return \Doctrine\Common\Cache\CacheProvider
+     */
+    protected static function initialize($config)
+    {
+        return new ApcCache();
+    }
+}

--- a/src/CacheProvider/ArrayCacheProvider.php
+++ b/src/CacheProvider/ArrayCacheProvider.php
@@ -1,0 +1,20 @@
+<?php  namespace Atrauzzi\LaravelDoctrine\CacheProvider;
+
+use Doctrine\Common\Cache\ArrayCache;
+
+/**
+ * Class MemcachedProvider
+ * @package Atrauzzi\LaravelDoctrine\CacheProvider
+ */
+class ArrayCacheProvider extends CacheProvider{
+
+    /**
+     * Sets up and returns the CacheProvider
+     * @param $config
+     * @return \Doctrine\Common\Cache\CacheProvider
+     */
+    protected static function initialize($config)
+    {
+        return new ArrayCache();
+    }
+}

--- a/src/CacheProvider/CacheProvider.php
+++ b/src/CacheProvider/CacheProvider.php
@@ -1,0 +1,33 @@
+<?php  namespace Atrauzzi\LaravelDoctrine\CacheProvider;
+
+abstract class CacheProvider {
+
+    protected static $required_configurations = [];
+
+    /**
+     * @param $config
+     * @return \Doctrine\Common\Cache\CacheProvider
+     * @throws \Exception
+     */
+    public static function getCacheProvider($config)
+    {
+        if(self::hasValidParameters($config))
+        {
+            throw new \InvalidArgumentException('Missing one or more required parameters ['.implode(', ',self::$required_configurations).']');
+        }
+
+        return self::initialize($config);
+    }
+
+    protected static function hasValidParameters($params)
+    {
+        return count(array_intersect(array_flip(static::$required_configurations), $params)) !== count(static::$required_configurations);
+    }
+
+    /**
+     * Sets up and returns the CacheProvider
+     * @param $config
+     * @return \Doctrine\Common\Cache\CacheProvider
+     */
+    abstract protected static function initialize($config);
+}

--- a/src/CacheProvider/CouchbaseProvider.php
+++ b/src/CacheProvider/CouchbaseProvider.php
@@ -1,0 +1,34 @@
+<?php  namespace Atrauzzi\LaravelDoctrine\CacheProvider;
+
+use Doctrine\Common\Cache\CouchbaseCache;
+
+/**
+ * Class MemcachedProvider
+ * @package Atrauzzi\LaravelDoctrine\CacheProvider
+ */
+class CouchbaseProvider extends CacheProvider{
+
+    protected static $required_configurations = ['hosts','user','password','bucket','persistent'];
+
+    /**
+     * Sets up and returns the CacheProvider
+     * @param $config
+     * @return \Doctrine\Common\Cache\CacheProvider
+     */
+    protected static function initialize($config)
+    {
+        $couchbase = new \Couchbase(
+            $config['hosts'],
+            $config['user'],
+            $config['password'],
+            $config['bucket'],
+            $config['persistent']
+        );
+
+        $cache = new CouchbaseCache();
+
+        $cache->setCouchbase($couchbase);
+
+        return $cache;
+    }
+}

--- a/src/CacheProvider/MemcacheProvider.php
+++ b/src/CacheProvider/MemcacheProvider.php
@@ -1,0 +1,27 @@
+<?php  namespace Atrauzzi\LaravelDoctrine\CacheProvider;
+
+use Doctrine\Common\Cache\MemcacheCache;
+
+/**
+ * Class MemcacheProvider
+ * @package Atrauzzi\LaravelDoctrine\CacheProvider
+ */
+class MemcacheProvider extends CacheProvider{
+
+    protected static $required_configurations = ['host','port'];
+
+    /**
+     * Sets up and returns the CacheProvider
+     * @param $config
+     * @return \Doctrine\Common\Cache\CacheProvider
+     */
+    protected static function initialize($config)
+    {
+        $memcache = new \Memcache();
+        $memcache->connect($config['host'], $config['port']);
+        $cache = new MemcacheCache();
+        $cache->setMemcache($memcache);
+
+        return $cache;
+    }
+}

--- a/src/CacheProvider/MemcachedProvider.php
+++ b/src/CacheProvider/MemcachedProvider.php
@@ -1,0 +1,27 @@
+<?php  namespace Atrauzzi\LaravelDoctrine\CacheProvider;
+
+use Doctrine\Common\Cache\MemcacheCached;
+
+/**
+ * Class MemcachedProvider
+ * @package Atrauzzi\LaravelDoctrine\CacheProvider
+ */
+class MemcachedProvider extends CacheProvider{
+
+    protected static $required_configurations = ['host','port'];
+
+    /**
+     * Sets up and returns the CacheProvider
+     * @param $config
+     * @return \Doctrine\Common\Cache\CacheProvider
+     */
+    protected static function initialize($config)
+    {
+        $memcached = new \Memcached();
+        $memcached->addserver($config['host'], $config['port']);
+        $cache = new MemcachedCache();
+        $cache->setMemcached($memcached);
+
+        return $cache;
+    }
+}

--- a/src/CacheProvider/RedisProvider.php
+++ b/src/CacheProvider/RedisProvider.php
@@ -1,0 +1,28 @@
+<?php  namespace Atrauzzi\LaravelDoctrine\CacheProvider;
+
+use Doctrine\Common\Cache\RedisCache;
+
+/**
+ * Class MemcachedProvider
+ * @package Atrauzzi\LaravelDoctrine\CacheProvider
+ */
+class RedisProvider extends CacheProvider{
+
+    protected static $required_configurations = ['host','port','database'];
+
+    /**
+     * Sets up and returns the CacheProvider
+     * @param $config
+     * @return \Doctrine\Common\Cache\CacheProvider
+     */
+    protected static function initialize($config)
+    {
+        $redis = new \Redis();
+        $redis->connect($config['host'],$config['port']);
+        $redis->select($config['database']);
+        $cache = new RedisCache();
+        $cache->setRedis($redis);
+
+        return $cache;
+    }
+}

--- a/src/CacheProvider/XcacheProvider.php
+++ b/src/CacheProvider/XcacheProvider.php
@@ -1,0 +1,20 @@
+<?php  namespace Atrauzzi\LaravelDoctrine\CacheProvider;
+
+use Doctrine\Common\Cache\XcacheCache;
+
+/**
+ * Class MemcachedProvider
+ * @package Atrauzzi\LaravelDoctrine\CacheProvider
+ */
+class XcacheProvider extends CacheProvider{
+
+    /**
+     * Sets up and returns the CacheProvider
+     * @param $config
+     * @return \Doctrine\Common\Cache\CacheProvider
+     */
+    protected static function initialize($config)
+    {
+        return new XcacheCache();
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -45,7 +45,7 @@
 
 				$debug = config('doctrine.debug', config('app.debug', false));
 
-				$cache = $debug ? null : $this->createCache();
+				$cache = $this->createCache();
 
 				$doctrineConfig = Setup::createConfiguration(
 					$debug,
@@ -204,20 +204,28 @@
 
 		}
 
-		/**
-		 * Selects the best caching implementation for the current environment.
-		 *
-		 * @return \Doctrine\Common\Cache\CacheProvider|null
-		 */
-		protected function createCache() {
-			$cacheProvider = config('doctrine.cache.provider', config('cache.default','Array'));
+
+        /**
+         * Initializes cache. Defaults to Array cache.
+         *
+         * @return \Doctrine\Common\Cache\CacheProvider
+         * @throws \Exception
+         * @throws \Symfony\Component\Debug\Exception\ClassNotFoundException
+         */
+        protected function createCache() {
+            if(is_null(config('doctrine.cache.provider'))) return null;
+
+			$cacheProvider = config('doctrine.cache.provider');
             $namespace = config('doctrine.cache.namespace', config('cache.prefix'));
 
-            $cache = CacheFactory::getInstance($cacheProvider, $namespace);
+            $cache = CacheFactory::getCacheProvider($cacheProvider, $namespace);
 
             return $cache;
 		}
 
+        /**
+         * @throws \Doctrine\DBAL\DBALException
+         */
         protected function registerCustomTypes()
         {
             foreach(config('doctrine.custom_types',array()) as $name=>$class)

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,7 +1,6 @@
 <?php namespace Atrauzzi\LaravelDoctrine {
 
 	use Illuminate\Support\ServiceProvider as Base;
-	//
 	use Doctrine\DBAL\Types\Type;
 	use Illuminate\Contracts\Foundation\Application;
 	use Doctrine\ORM\Configuration as DoctrineConfig;
@@ -211,94 +210,12 @@
 		 * @return \Doctrine\Common\Cache\CacheProvider|null
 		 */
 		protected function createCache() {
+			$cacheProvider = config('doctrine.cache.provider', config('cache.default','Array'));
+            $namespace = config('doctrine.cache.namespace', config('cache.prefix'));
 
-			$cacheProvider = config('doctrine.cache.provider', config('cache.default'));
+            $cache = CacheFactory::getInstance($cacheProvider, $namespace);
 
-			switch($cacheProvider) {
-
-				case 'memcache':
-
-					$memcache = new \Memcache();
-					$memcache->connect(
-						config('doctrine.cache.memcache.host'),
-						config('doctrine.cache.memcache.port')
-					);
-
-					$cache = new \Doctrine\Common\Cache\MemcacheCache();
-
-					$cache->setMemcache($memcache);
-
-				break;
-
-				case 'memcached':
-
-					$memcache = new \Memcached();
-					$memcache->addServer(
-						config('doctrine.cache.memcached.host', config('cache.stores.memcached.0.host')),
-						config('doctrine.cache.memcached.port', config('cache.stores.memcached.0.port'))
-					);
-
-					$cache = new \Doctrine\Common\Cache\MemcachedCache();
-
-					$cache->setMemcached($memcache);
-
-				break;
-
-				case 'couchbase':
-
-					$couchbase = new \Couchbase(
-						config('doctrine.cache.couchbase.hosts'),
-						config('doctrine.cache.couchbase.user'),
-						config('doctrine.cache.couchbase.password'),
-						config('doctrine.cache.couchbase.bucket'),
-						config('doctrine.cache.couchbase.persistent')
-					);
-
-					$cache = new \Doctrine\Common\Cache\CouchbaseCache();
-
-					$cache->setCouchbase($couchbase);
-
-				break;
-
-				case 'redis':
-
-					$redis = new \Redis();
-					$redis->connect(
-						config('doctrine.cache.redis.host', config('database.redis.default.host')),
-						config('doctrine.cache.redis.port', config('database.redis.default.port'))
-					);
-
-					if($database = config('doctrine.cache.redis.database', config('database.redis.default.database')))
-						$redis->select($database);
-
-					$cache = new \Doctrine\Common\Cache\RedisCache();
-
-					$cache->setRedis($redis);
-
-				break;
-
-				case 'apc':
-					$cache = new \Doctrine\Common\Cache\ApcCache();
-				break;
-
-				case 'xcache':
-					$cache = new \Doctrine\Common\Cache\XcacheCache();
-				break;
-
-				default:
-					$cache = new \Doctrine\Common\Cache\ArrayCache();
-				break;
-
-			}
-
-			if(
-				$cache instanceof \Doctrine\Common\Cache\CacheProvider
-				&& $namespace = config('doctrine.cache.namespace', config('cache.prefix'))
-			)
-				$cache->setNamespace($namespace);
-
-			return $cache;
-
+            return $cache;
 		}
 
         protected function registerCustomTypes()


### PR DESCRIPTION
Includes a mapping of cache providers in configuration and the ability to create/augment cache providers.

Thought I would send this over. Not sure why I refactored the cache initialization to the factory pattern other than I was going to add some tests and thought this architecture would help for testing. I've not really tested this code other than a basic 'does it still load'. As there were no existing tests, I'm assuming testing is pretty rudimentary at this point anyways, hence sending this over without tests.
