### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,10 +37,14 @@ Most of Doctrine's functionality derives from defining your schema (via annotati
 Adapted from [Doctrine's documentation](http://goo.gl/XQ3qg):
 
     <?php
+    
+    // for Laravel files, you need to include the facade
+    use EntityManager;
+    
     $user = new User;
     $user->setName('Mr.Right');
-    Doctrine::persist($user);
-    Doctrine::flush();
+    EntityManager::persist($user);
+    EntityManager::flush();
 
 It is recommended that you read through all of the [ORM documentation](http://goo.gl/kpAeX).  Try using Laravel's console to experiment and go through the tutorials.
 


### PR DESCRIPTION
The readme could be more specific, as this is a laravel package, it might be better to update the example. I've added the `use Facade`, and changed `Doctrine::` to `EntityManager::` because that is what is declared in config/app.php  as a facade. Using the examples provided in the current readme are not working.