### PR TITLE
Fix #67

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -237,6 +237,9 @@
                 if(!Type::hasType($name)){
                     Type::addType($name, $class);
                 }
+                else{
+                    Type::overrideType($name, $class);
+                }
             }
         }
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -234,10 +234,10 @@
         {
             foreach(config('doctrine.custom_types',array()) as $name=>$class)
             {
-                Type::addType($name, $class);
+                if(!Type::hasType($name)){
+                    Type::addType($name, $class);
+                }
             }
         }
-
     }
-
 }


### PR DESCRIPTION
I know you suggested you thought this was a bit hacky but I think without Doctrine having a method to clear out custom types (or figuring out why a reboot isn't actually doing a full reboot which is probably outside the scope of this package), adding in the check if it already exists and if it does overriding it should meet 95% of people's use cases and allow the package to be used with testing.