### PR TITLE
1.1.x

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -66,21 +66,40 @@
 	/*
 	 * By default, this package mimics the database configuration from Laravel.
 	 *
-	 * You can override it in whole or in part here.
+	 * You can override it in whole or in part here. The 'database' and 'username'
+	 * laravel settings will be automatically converted to the proper doctrine 'dbname'
+	 * and 'user' settings. Other custom laravel to doctrine mappings can be added on
+	 * a per configuration basis by including a 'mappings' entry with 'laravel'=>'doctrine'
+	 * mappings (see the sqlite configuration for an example).
 	 *
 	 * This array passes right through to the EntityManager factory. For
 	 * example, here you can set additional connection details like "charset".
 	 *
 	 * http://doctrine-dbal.readthedocs.org/en/latest/reference/configuration.html#connection-details
 	 */
-	'connection' => [
+	'connections' => [
+        // Override your laravel environment database selection here if desired
+        // 'default' => 'mysql',
 
-		'driver' => 'mysqli',
-		'host'      => env('DB_HOST', 'localhost'),
-		'dbname'  => env('DB_DATABASE', 'forge'),
-		'user'  => env('DB_USERNAME', 'forge'),
-		'password'  => env('DB_PASSWORD', ''),
-		'prefix' => ''
+        // Override your laravel values here if desired.
+        /*'mysql' => [
+            'driver' => 'mysqli',
+            'host'      => env('DB_HOST', 'localhost'),
+            'dbname'  => env('DB_DATABASE', 'forge'),
+            'user'  => env('DB_USERNAME', 'forge'),
+            'password'  => env('DB_PASSWORD', ''),
+            'prefix' => ''
+        ],*/
+
+        // Some preset configurations to map laravel sqlite configs to doctrine
+        'sqlite' => [
+            'driver' => 'pdo_sqlite',
+            'mappings' => [
+                'database' => 'path'
+            ]
+        ]
+
+
 	],
 
 	/*

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -14,7 +14,11 @@
 	use Doctrine\ORM\Mapping\Driver\XmlDriver;
 
 
-	class ServiceProvider extends Base {
+    /**
+     * Class ServiceProvider
+     * @package Atrauzzi\LaravelDoctrine
+     */
+    class ServiceProvider extends Base {
 
 		/**
 		 * Bootstrap the application events.
@@ -43,84 +47,11 @@
 
 			$this->app->singleton('Doctrine\ORM\EntityManager', function (Application $app) {
 
-				$debug = config('doctrine.debug', config('app.debug', false));
-
-				$cache = $this->createCache();
-
-				$doctrineConfig = Setup::createConfiguration(
-					$debug,
-					config('doctrine.proxy_classes.directory', storage_path('doctrine/proxies')),
-					// Note: Don't worry, caches are configured below.
-					null
-				);
-
-				$metadataConfig = config('doctrine.metadata', [
-					'driver' => 'config'
-				]);
-
-				if(!empty($metadataConfig) && isset($metadataConfig[0]) && is_array($metadataConfig[0])) {
-
-					$metadataDriver = new \Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain();
-
-					foreach($metadataConfig as $subDriverConfig) {
-
-						if(!is_array($subDriverConfig))
-							continue;
-
-						$metadataDriver->addDriver(
-							$this->createMetadataDriver($doctrineConfig, $subDriverConfig),
-							array_get($subDriverConfig, 'namespace', 'App')
-						);
-						if (isset($subDriverConfig['namespace']) && isset($subDriverConfig['alias'])) {
-							$doctrineConfig->addEntityNamespace($subDriverConfig['alias'],$subDriverConfig['namespace']);
-						}
-					}
-
-				}
-				else {
-					$metadataDriver = $this->createMetadataDriver($doctrineConfig, $metadataConfig);
-				}
-
-				$doctrineConfig->setMetadataDriverImpl($metadataDriver);
-
-				//add in trig functions to doctrine for mysql
-				$doctrineConfig->setCustomNumericFunctions(array(
-					'ACOS'    => 'DoctrineExtensions\Query\Mysql\Acos',
-					'ASIN'    => 'DoctrineExtensions\Query\Mysql\Asin',
-					'ATAN'    => 'DoctrineExtensions\Query\Mysql\Atan',
-					'ATAN2'   => 'DoctrineExtensions\Query\Mysql\Atan2',
-					'COS'     => 'DoctrineExtensions\Query\Mysql\Cos',
-					'COT'     => 'DoctrineExtensions\Query\Mysql\Cot',
-					'DEGREES' => 'DoctrineExtensions\Query\Mysql\Degrees',
-					'RADIANS' => 'DoctrineExtensions\Query\Mysql\Radians',
-					'SIN'     => 'DoctrineExtensions\Query\Mysql\Sin',
-					'TAN'     => 'DoctrineExtensions\Query\Mysql\Tan'
-				));
-
-				// Note: These must occur after Setup::createAnnotationMetadataConfiguration() in order to set custom namespaces properly
-				if($cache) {
-					$doctrineConfig->setMetadataCacheImpl($cache);
-					$doctrineConfig->setQueryCacheImpl($cache);
-					$doctrineConfig->setResultCacheImpl($cache);
-				}
-
-				$doctrineConfig->setAutoGenerateProxyClasses(config('doctrine.proxy_classes.auto_generate', !$debug));
-				$doctrineConfig->setDefaultRepositoryClassName(config('doctrine.default_repository', '\Doctrine\ORM\EntityRepository'));
-				$doctrineConfig->setSQLLogger(config('doctrine.sql_logger'));
-
-				if($proxyClassNamespace = config('doctrine.proxy_classes.namespace'))
-					$doctrineConfig->setProxyNamespace($proxyClassNamespace);
-
-				// Trap doctrine events, to support entity table prefix
-				$eventManager = new EventManager();
-				if($prefix = config('doctrine.connection.prefix'))
-					$eventManager->addEventListener(Events::loadClassMetadata, new Listener\Metadata\TablePrefix($prefix));
-
-				//
-				// At long last!
-				//
-				return EntityManager::create(config('doctrine.connection'), $doctrineConfig, $eventManager);
-
+                return EntityManager::create(
+                    $this->getDoctrineConnection(),
+                    $this->createDoctrineConfig($this->createCache()),
+                    $this->createEventManager()
+                );
 			});
 
 			$this->app->singleton('Doctrine\ORM\Tools\SchemaTool', function (Application $app) {
@@ -242,5 +173,87 @@
                 }
             }
         }
+
+        /**
+         * @param $cache
+         * @return DoctrineConfig
+         * @throws \Doctrine\ORM\ORMException
+         */
+        protected function createDoctrineConfig($cache)
+        {
+            $debug = config('doctrine.debug', config('app.debug', false));
+            $metadataConfig = config('doctrine.metadata', ['driver' => 'config']);
+            $proxyDir = config('doctrine.proxy_classes.directory', storage_path('doctrine/proxies'));
+            // Note: Don't worry, caches are configured below.
+            $doctrineConfig = Setup::createConfiguration($debug, $proxyDir, null);
+            if (! empty($metadataConfig) && isset($metadataConfig[0]) && is_array($metadataConfig[0]))
+            {
+                $metadataDriver = new \Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain();
+                foreach ($metadataConfig as $subDriverConfig)
+                {
+                    if (! is_array($subDriverConfig))
+                        continue;
+                    $metadataDriver->addDriver(
+                        $this->createMetadataDriver($doctrineConfig, $subDriverConfig),
+                        array_get($subDriverConfig, 'namespace', 'App')
+                    );
+                    if (isset($subDriverConfig['namespace']) && isset($subDriverConfig['alias']))
+                    {
+                        $doctrineConfig->addEntityNamespace($subDriverConfig['alias'], $subDriverConfig['namespace']);
+                    }
+                }
+            } else
+            {
+                $metadataDriver = $this->createMetadataDriver($doctrineConfig, $metadataConfig);
+            }
+            $doctrineConfig->setMetadataDriverImpl($metadataDriver);
+            //add in trig functions to doctrine for mysql
+            $doctrineConfig->setCustomNumericFunctions(array(
+                'ACOS'    => 'DoctrineExtensions\Query\Mysql\Acos',
+                'ASIN'    => 'DoctrineExtensions\Query\Mysql\Asin',
+                'ATAN'    => 'DoctrineExtensions\Query\Mysql\Atan',
+                'ATAN2'   => 'DoctrineExtensions\Query\Mysql\Atan2',
+                'COS'     => 'DoctrineExtensions\Query\Mysql\Cos',
+                'COT'     => 'DoctrineExtensions\Query\Mysql\Cot',
+                'DEGREES' => 'DoctrineExtensions\Query\Mysql\Degrees',
+                'RADIANS' => 'DoctrineExtensions\Query\Mysql\Radians',
+                'SIN'     => 'DoctrineExtensions\Query\Mysql\Sin',
+                'TAN'     => 'DoctrineExtensions\Query\Mysql\Tan'
+            ));
+            // Note: These must occur after Setup::createAnnotationMetadataConfiguration() in order to set custom namespaces properly
+            if ($cache)
+            {
+                $doctrineConfig->setMetadataCacheImpl($cache);
+                $doctrineConfig->setQueryCacheImpl($cache);
+                $doctrineConfig->setResultCacheImpl($cache);
+            }
+            $doctrineConfig->setAutoGenerateProxyClasses(config('doctrine.proxy_classes.auto_generate', ! $debug));
+            $doctrineConfig->setDefaultRepositoryClassName(config('doctrine.default_repository', '\Doctrine\ORM\EntityRepository'));
+            $doctrineConfig->setSQLLogger(config('doctrine.sql_logger'));
+            if ($proxyClassNamespace = config('doctrine.proxy_classes.namespace'))
+                $doctrineConfig->setProxyNamespace($proxyClassNamespace);
+            return $doctrineConfig;
+        }
+
+        /**
+         * @return EventManager
+         */
+        protected function createEventManager()
+        {
+            $eventManager = new EventManager();
+            // Trap doctrine events, to support entity table prefix
+            if ($prefix = config('doctrine.connection.prefix'))
+                $eventManager->addEventListener(Events::loadClassMetadata, new TablePrefix($prefix));
+            return $eventManager;
+        }
+
+        /**
+         * @return mixed
+         */
+        protected function getDoctrineConnection()
+        {
+            return config('doctrine.connection');
+        }
+
     }
 }


### PR DESCRIPTION
I attempted to clean up the way the Entity Manager is registered. I didn't do to much other than create functions for the various components in the ServiceProvider but an hoping it lends itself to better testing as we go.

This request also includes a change to the way the connection is configured to more closely match laravel and to use the laravel database configurations more accurately while still allowing for a powerful override and mapping system. Also updated the config documentation to explain the connection mapping in a bit more detail.

As a suggestion, I think it might be a good time to tag a 1.0.1 version before this merge and use this PR for a 1.1 branch so I don't break everyones code like I did with the Cache Factory... Then we can add a 1.1.x-dev version to our composer files to be working with latest stuff without affecting anyone that has a 1.0.x version that they may actually be using. What do you think?