### PR TITLE
provider must be the ServiceProvider with fully qualified namespace.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ If desired, add the following to your `facades` array in the same file:
 
 You need to run this command publish package configuration.
 
-`php artisan vendor:publish --provider="Vendor\atrauzzi\LaravelDoctrine\src\ServiceProvider" --tag="config"`
+`php artisan vendor:publish --provider="Atrauzzi\LaravelDoctrine\ServiceProvider" --tag="config"`
 
 
 #### Usage


### PR DESCRIPTION
Publish command was incorrect in the `readme.md`. You need to use the fully qualified namespace of the ServiceProvider.

The example  in [Laravel docs] (http://laravel.com/docs/5.1/packages#publishing-file-groups) trap if you just blind copy it.