### PR TITLE
Fix for #105. Map 'mysql' to 'pdo_mysql'

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -293,6 +293,11 @@
          */
         private function mapToDoctrineConfigs($config)
         {
+            if ($config['driver'] == 'mysql')
+            {
+                $config['driver'] = 'pdo_mysql';
+            }
+			
             $mappings = [
                 'database' => 'dbname',
                 'username' => 'user'


### PR DESCRIPTION
Seemed like an OK place to map that value for issue #105.