### PR TITLE
setToken isn't really right

### DIFF
--- a/src/DoctrineAuthenticator.php
+++ b/src/DoctrineAuthenticator.php
@@ -42,7 +42,7 @@ class DoctrineAuthenticator implements UserProvider {
      */
     public function updateRememberToken(Authenticatable $user, $token)
     {
-        $user->setToken($token);
+        $user->setRememberToken($token);
         app('\Doctrine\ORM\EntityManager')->flush($user);
     }
 


### PR DESCRIPTION
setToken should be setRememberToken because the column in the user table and the property of the user entity are called remember_token, therefore the function name shouldn't be setToken but setRememberToken