### PR TITLE
Move custom numeric functions array to config

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -211,6 +211,19 @@
         'json' => 'Atrauzzi\LaravelDoctrine\Type\Json'
     ],
 
+	'custom_numeric_functions' => [
+		'ACOS' => 'DoctrineExtensions\Query\Mysql\Acos',
+		'ASIN' => 'DoctrineExtensions\Query\Mysql\Asin',
+		'ATAN' => 'DoctrineExtensions\Query\Mysql\Atan',
+		'ATAN2' => 'DoctrineExtensions\Query\Mysql\Atan2',
+		'COS' => 'DoctrineExtensions\Query\Mysql\Cos',
+		'COT' => 'DoctrineExtensions\Query\Mysql\Cot',
+		'DEGREES' => 'DoctrineExtensions\Query\Mysql\Degrees',
+		'RADIANS' => 'DoctrineExtensions\Query\Mysql\Radians',
+		'SIN' => 'DoctrineExtensions\Query\Mysql\Sin',
+		'TAN' => 'DoctrineExtensions\Query\Mysql\Tan'
+	],
+
     'auth' => [
         //'authenticator' => 'Atrauzzi\LaravelDoctrine\DoctrineAuthenticator',
         //'model' => 'App\Models\User',

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -220,18 +220,7 @@
             }
             $doctrineConfig->setMetadataDriverImpl($metadataDriver);
             //add in trig functions to doctrine for mysql
-            $doctrineConfig->setCustomNumericFunctions(array(
-                'ACOS'    => 'DoctrineExtensions\Query\Mysql\Acos',
-                'ASIN'    => 'DoctrineExtensions\Query\Mysql\Asin',
-                'ATAN'    => 'DoctrineExtensions\Query\Mysql\Atan',
-                'ATAN2'   => 'DoctrineExtensions\Query\Mysql\Atan2',
-                'COS'     => 'DoctrineExtensions\Query\Mysql\Cos',
-                'COT'     => 'DoctrineExtensions\Query\Mysql\Cot',
-                'DEGREES' => 'DoctrineExtensions\Query\Mysql\Degrees',
-                'RADIANS' => 'DoctrineExtensions\Query\Mysql\Radians',
-                'SIN'     => 'DoctrineExtensions\Query\Mysql\Sin',
-                'TAN'     => 'DoctrineExtensions\Query\Mysql\Tan'
-            ));
+            $doctrineConfig->setCustomNumericFunctions(config('doctrine.custom_numeric_functions'));
             // Note: These must occur after Setup::createAnnotationMetadataConfiguration() in order to set custom namespaces properly
             if ($cache)
             {


### PR DESCRIPTION
I think it'd be better if the content of setCustomNumericFunctions in the ServiceProvider would be moved to the config file, so that it would be easy to customize this. What do you think?